### PR TITLE
Update the mobile icon in Contact Me section

### DIFF
--- a/index.html
+++ b/index.html
@@ -479,7 +479,7 @@
                             </div>
                             <div class="contact-item">
                                 <div class="icon">
-                                    <i class="fas fa-user-graduate"></i>
+                                    <i class="fas fa-mobile-alt"></i>
                                     <span>Mobile Number</span>
                                 </div>
                                 <p>


### PR DESCRIPTION
Instead of a graduate icon, I've corrected the icon for mobile number Either fa-mobile or fa-mobile-alt would work but I personally think alt version looks more consistent with other icons.